### PR TITLE
Fix a bug when multiple frames present in single chunk.

### DIFF
--- a/src/transformers.mjs
+++ b/src/transformers.mjs
@@ -13,8 +13,8 @@ export class Decode extends Transform {
       if(consumed > 0) {
         const nextFrame = consumed + length;
         if(chunk.length >= nextFrame) {
-          this.push(chunk.slice(consumed, nextFrame));
-          chunk = chunk.slice(nextFrame);
+          this.push(chunk.subarray(consumed, nextFrame));
+          chunk = chunk.subarray(nextFrame);
         }
         else { break; }
       }

--- a/src/transformers.mjs
+++ b/src/transformers.mjs
@@ -1,12 +1,14 @@
 import { Transform } from "stream";
 
+
+
 export class Decode extends Transform {
   _transform(chunk, enc, cont) {
-    while (chunk.length > 0) {
-      if (this.buffer) {
-        chunk = Buffer.concat([this.buffer, chunk]);
-      }
+    if (this.buffer) {
+      chunk = Buffer.concat([this.buffer, chunk]);
+    }
 
+    while (chunk.length > 0) {
       const [consumed, length] = decodeLength(chunk);
       if(consumed > 0) {
         const nextFrame = consumed + length;


### PR DESCRIPTION
`this.buffer` of the Decode class will be concated in front of the chunk more than one time when there are multiple frames in one chunk. Therefore I move the concat lines out of the while loop.
The `buf.slice` call is also replaced with `buf.subarray` since it has been deprecated since node 14.